### PR TITLE
ARC-185: Restyle group selection + always show sidebar on mac

### DIFF
--- a/pages/styles/popup.css
+++ b/pages/styles/popup.css
@@ -28,6 +28,11 @@ label, input{
     margin-bottom: 5px;
 }
 
+input[type="checkbox"] {
+    vertical-align: middle;
+    width: initial;
+}
+
 input[type="button"]{
     margin: 10px auto 5px;
     padding: 8px 14px;

--- a/pages/styles/popup.css
+++ b/pages/styles/popup.css
@@ -1,3 +1,16 @@
+/* Always show the scrollbar on Mac
+SOURCE: https://davidwalsh.name/osx-overflow */
+::-webkit-scrollbar {
+   -webkit-appearance: none;
+   width: 7px;
+}
+
+::-webkit-scrollbar-thumb {
+   border-radius: 4px;
+   background-color: rgba(0,0,0,.5);
+   -webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
 body {
     overflow: hidden;
     margin: 0;

--- a/scripts/archivist/form.js
+++ b/scripts/archivist/form.js
@@ -20,7 +20,7 @@ function saveField(element) {
 }
 
 Archivist.form.setInputEvents = () => {
-  $('input, textarea').on(
+  $('input[type!="checkbox"], textarea').on(
     'keyup, change', (event) => {
       const changedElement = event.target;
       saveField(changedElement);

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -177,14 +177,13 @@ $(document).ready(() => {
     const defaultGroups = ['Generic', 'Website'];
     groupData.forEach((group) => {
       // Add Section
-      let isDefault = defaultGroups.includes(group.name);
+      const isDefault = defaultGroups.includes(group.name);
       const sectionDiv = $(`<div id="section-${group.name.toLowerCase()}">
                               <h1>
                                 <input type="checkbox" data-section-name="${group.name.toLowerCase()}" ${isDefault ? 'style="display:none;"' : ''}/>
                                 ${group.name}
                               </h1>
                             </div>`);
-      console.log(sectionDiv.children('input'));
       sectionDiv.find('input').click(handleGroupClick);
 
       const fieldsContainer = $(`<div id="fields-${group.name.toLowerCase()}"></div>`);

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -123,14 +123,14 @@ $(document).ready(() => {
   // Toggles section on click of metadata group checkbox
   function handleGroupClick() {
     const sectionName = $(this).data('section-name');
-    $(`#section-${sectionName}`).toggle();
+    $(`#fields-${sectionName}`).toggle();
   }
 
   Archivist.popup.fillFormWithObject = (formData) => {
     if (formData !== undefined) {
       Object.keys(formData.fields).forEach((popupFieldId) => {
         const group = popupFieldId.split('_')[0];
-        const groupFields = $(`#section-${group}`);
+        const groupFields = $(`#fields-${group}`);
         if (!groupFields.is(':visible')) {
           groupFields.toggle();
           $(`input[data-section-name="${group}"]`).prop('checked', 'checked');
@@ -174,35 +174,33 @@ $(document).ready(() => {
 
   function generateFormHtml(groupData) {
     const sections = [];
-    const checkboxDiv = $('<div class="metadata-checkboxes"><h1>Metadata Groups</h1></div>');
     const defaultGroups = ['Generic', 'Website'];
     groupData.forEach((group) => {
       // Add Section
-      const sectionDiv = $(`<div id="section-${group.name.toLowerCase()}"><h1>${group.name}</h1></div>`);
-      const metadataInputs = Archivist.html.generateMetadataInputs(group.fields, group.name);
-      metadataInputs.forEach((htmlElement) => {
-        $(htmlElement).appendTo(sectionDiv);
-      });
-      sections.unshift(sectionDiv);
+      let isDefault = defaultGroups.includes(group.name);
+      const sectionDiv = $(`<div id="section-${group.name.toLowerCase()}">
+                              <h1>
+                                <input type="checkbox" data-section-name="${group.name.toLowerCase()}" ${isDefault ? 'style="display:none;"' : ''}/>
+                                ${group.name}
+                              </h1>
+                            </div>`);
+      console.log(sectionDiv.children('input'));
+      sectionDiv.find('input').click(handleGroupClick);
 
-      // Add checkbox
-      let disabledText = '';
-      if (defaultGroups.includes(group.name)) {
-        disabledText = 'disabled="disabled" checked="checked"';
-      } else {
-        sectionDiv.toggle();
+      const fieldsContainer = $(`<div id="fields-${group.name.toLowerCase()}"></div>`);
+      Archivist.html.generateMetadataInputs(group.fields, group.name).forEach((htmlElement) => {
+        $(htmlElement).appendTo(fieldsContainer);
+      });
+
+      if (!defaultGroups.includes(group.name)) {
+        fieldsContainer.toggle();
       }
 
-      const groupCheckbox = $(`<label>
-                                <input ${disabledText} type="checkbox"
-                                data-section-name="${group.name.toLowerCase()}" /> ${group.name}
-                              </label>`);
-      groupCheckbox.children('input').click(handleGroupClick);
-      groupCheckbox.appendTo(checkboxDiv);
+      fieldsContainer.appendTo(sectionDiv);
+      sections.unshift(sectionDiv);
     });
 
     Archivist.form.prependElements(sections);
-    Archivist.form.prependElement(checkboxDiv[0].childNodes);
 
     setDefaultFields(Archivist.curTab);
     initScrape();


### PR DESCRIPTION
- The checkbox for default groups are now hidden as this was causing confusion before
- Scrollbar will now be always visible on Mac OS X -- even if it is set to hide by default
- Group selection is now inline to make it more clear

<img width="355" alt="screen shot 2017-05-02 at 5 36 29 pm" src="https://cloud.githubusercontent.com/assets/5169821/25640585/12224b28-2f5e-11e7-8b5c-113d45115445.png">
